### PR TITLE
Features : Display error messages

### DIFF
--- a/src/Browser.ts
+++ b/src/Browser.ts
@@ -1,5 +1,6 @@
 import { BrowserName } from "./types";
 import { exec } from "child_process";
+import { showToast, ToastStyle } from "@raycast/api";
 
 interface BrowserConfig {
   name: BrowserName;
@@ -35,6 +36,11 @@ export class Browser {
   public open(profile: string): void {
     exec(`${this.entrypoint} login ${profile} --stdout`, (error, stdout, stderr) => {
       if (error) {
+        showToast(
+          ToastStyle.Failure,
+          "Error while running aws-vault login",
+          error.message,
+        );
         console.error(`error: ${error.message}`);
         return;
       }


### PR DESCRIPTION
My aws-vault sometimes has errors when executing the aws-login command.
Without running `npm run dev`、I couldn't read error messages.

When an error occurs, Raycast displays the error using Toast.